### PR TITLE
Removes the dark menu bar from Gist

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,14 @@
   "default_locale": "en",
   "permissions": [
     "contentSettings",
-    "https://github.com/*"
+    "https://github.com/*",
+    "https://gist.github.com/*"
   ],
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/*"
+        "https://github.com/*",
+        "https://gist.github.com/*"
       ],
       "js": [
         "src/inject/inject.js"


### PR DESCRIPTION
Gist also adopted this ugly dark menu bar

https://gist.github.com/

![captura de tela de 2017-02-12 00 44 33](https://cloud.githubusercontent.com/assets/6979335/22859249/75f28b08-f0bc-11e6-84bd-b13f11727ad5.png)
